### PR TITLE
Feature/remember last position of cursor inside previous window

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,52 @@
+#! env -S make
+
+NAME = mousefollowsfocus
+UUID = $(NAME)@matthes.biz
+
+.PHONY: build install enable disable test show remove clean trace
+
+
+build:
+	mkdir -p build/
+	gnome-extensions pack --force --out-dir=build
+
+
+deploy:
+	gnome-extensions install --force build/$(UUID).shell-extension.zip
+
+
+install: build remove deploy clean
+
+
+test: install
+	env GNOME_SHELL_SLOWDOWN_FACTOR=2 \
+		MUTTER_DEBUG_DUMMY_MODE_SPECS=1200x1000 \
+	 	MUTTER_DEBUG_DUMMY_MONITOR_SCALES=1 \
+		dbus-run-session -- gnome-shell --nested --wayland
+
+
+monitor:
+	echo '[Ctrl]+[c] for interrupting this output'
+	which journalctl && journalctl -f -o cat /usr/bin/gnome-shell
+
+
+info:
+	gnome-extensions info $(UUID)
+
+
+enable: install
+	gnome-extensions enable $(UUID)
+
+
+disable:
+	gnome-extensions disable $(UUID)
+
+
+remove:
+	rm -rf $(HOME)/.local/share/gnome-shell/extensions/$(UUID)
+
+
+clean:
+	rm -rf build/ po/*.mo
+
+## End of Makefile ##

--- a/extension.js
+++ b/extension.js
@@ -41,6 +41,21 @@ function dbg_log(message) {
     }
 }
 
+
+function focus_warp_pointer(win, mouse_x, mouse_y) {
+    let wt = win.get_title();
+    let rect = win.get_buffer_rect();
+
+    let seat = Clutter.get_default_backend().get_default_seat();
+    if (seat !== null) {
+        let nx = rect.x + rect.width / 2;
+        let ny = rect.y + rect.height / 2;
+        dbg_log(`targeting new position at middle (${nx},${ny}) of window: ${wt}`);
+        seat.warp_pointer(nx, ny);
+    } else {
+        dbg_log(`focus_changed: seat is null for window: ${wt}`);
+    }
+}
 function focus_changed(win) {
     let wt = win.get_title();
     dbg_log(`focus_changed: window focus event received from : ${wt}`);
@@ -60,17 +75,10 @@ function focus_changed(win) {
             // Ignore this and similar windows.
             dbg_log(`window too small, discarding event of window: ${wt}`);
         } else {
-            dbg_log('targeting new window');
-            let seat = Clutter.get_default_backend().get_default_seat();
-            if (seat !== null) {
-                seat.warp_pointer(rect.x + rect.width / 2, rect.y + rect.height / 2);
+            focus_warp_pointer(win, mouse_x, mouse_y);
             }
-            else {
-                dbg_log('seat is null!');
             }
-        }
-
-    }
+    dbg_log(`focus_changed: window focus event processed for: ${wt}`);
 }
 
 function connect_to_window(win) {

--- a/extension.js
+++ b/extension.js
@@ -24,7 +24,7 @@ function cursor_within_window(mouse_x, mouse_y, win) {
     // the pointer to jump around eratically.
     let rect = win.get_buffer_rect();
 
-    dbg_log(`window rect: ${rect.x}:${rect.y} - ${rect.width}:${rect.height}`);
+    dbg_log(`window at: (${rect.x},${rect.y}) window size: ${rect.width}x${rect.height} mouse at: (${mouse_x},${mouse_y})`);
 
     return mouse_x >= rect.x &&
         mouse_x <= rect.x + rect.width &&
@@ -42,21 +42,23 @@ function dbg_log(message) {
 }
 
 function focus_changed(win) {
+    let wt = win.get_title();
+    dbg_log(`focus_changed: window focus event received from : ${wt}`);
+
     const actor = get_window_actor(win);
-    dbg_log('window focus event received');
     if (actor) {
         let rect = win.get_buffer_rect();
-
+        
         let [mouse_x, mouse_y, _] = global.get_pointer();
 
         if (cursor_within_window(mouse_x, mouse_y, win)) {
-            dbg_log('pointer within window, discarding event');
+            dbg_log(`pointer within window, discarding event of window: ${wt}`);
         } else if (overview.visible) {
-            dbg_log('overview visible, discarding event');
+            dbg_log(`overview visible, discarding event of window: ${wt}`);
         } else if (rect.width < 10 && rect.height < 10) {
             // xdg-copy creates a 1x1 pixel window to capture mouse events.
             // Ignore this and similar windows.
-            dbg_log('window too small, discarding event');
+            dbg_log(`window too small, discarding event of window: ${wt}`);
         } else {
             dbg_log('targeting new window');
             let seat = Clutter.get_default_backend().get_default_seat();
@@ -102,12 +104,13 @@ class Extension {
         }
 
         this.create_signal = global.display.connect('window-created', function (ignore, win) {
-            dbg_log(`window created ${win}`);
+            let wt = win.get_title();
+            dbg_log(`window created: ${wt}, ignore: ${ignore}`);
 
             connect_to_window(win);
         });
 
-        this.hide_signal = overview.connect('hidden', function() {
+        this.hide_signal = overview.connect('hidden', function () {
             // the focus might change whilst we're in the overview, i.e. by
             // searching for an already open app.
             const win = get_focused_window();

--- a/extension.js
+++ b/extension.js
@@ -105,6 +105,7 @@ function focus_changed(win) {
         } else {
             focus_warp_pointer(win, mouse_x, mouse_y);
         }
+        _last_win = win;
     }
     dbg_log(`focus_changed: window focus event processed for: ${wt}`);
 }

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "Mouse Follows Focus",
-  "description": "Are you a power-user?\nDo you like using Super+1,2,3 to access your favorite apps?\nAre you annoyed that you have to manually move your mouse between screens because it can't keep up with your keyboard shortcuts?\nThen this extension is for you!\n\nThis simple GNOME shell extension does the opposite of the 'focus follows mouse' setting. It makes the mouse follow your keyboard focus. Whenever you focus a window, if the cursor isn't already in it, it will jump to the windows center, making it easy to interact with it.",
+  "description": "It makes the mouse follow your keyboard focus. Whenever you focus a window it will jump to the last position of the cursor inside the window or the windows center, making it easy to interact with it.\nAre you a power-user?\nDo you like using Super+1,2,3 to access your favorite apps?\nAre you annoyed that you have to manually move your mouse between screens because it can't keep up with your keyboard shortcuts?\nThen this extension is for you!\n\nThis simple GNOME shell extension does the opposite of the 'focus follows mouse' setting.",
   "uuid": "mousefollowsfocus@matthes.biz",
   "shell-version": [
     "41",

--- a/metadata.json
+++ b/metadata.json
@@ -8,6 +8,6 @@
     "43",
     "44"
   ],
-  "version": 5,
+  "version": 6,
   "url": "https://github.com/LeonMatthes/mousefollowsfocus"
 }


### PR DESCRIPTION
## Current behavior

- After a window receives focus, the extension:
  - Checks if the cursor already is inside the window
  - When the cursor isn't then it moves the cursor to the center of that window.
  - Otherwise, it doesn't change the cursor position.

## Proposed behavior

- After a window receives focus, the extension:
  - Checks if the cursor already is inside the window.
  - Checks if it has the last cursor position inside the window.
  - If positive then it doesn't change the cursor position
  - Otherwise:
    - When it has the last cursor position then it moves the cursor to this position.
    - Otherwise, it moves the cursor to the center of that window.

## Advantages

The last position when compared with window center positioning has the following advantages:

- It's a better guess of what would be the shortest path from the cursor position to the next click position.
- It considers users' intentions for cursor placement.
- It keeps the same advantages of the previous approach.

## Disavantages

- It could raise involuntary click incident rates as it puts often the cursor near the last clicked widget.
- Sometimes users prefer fixed positions.
- The center of the window is the shortest distance to all points inside the window, thus being better positioned for fast movement. 
  - However, mouse clicks tend to concentrate on some hot spots instead of being linearly distributed through the window.

