### PR TITLE
Update to Gnome Shell version 46

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -2,7 +2,7 @@
     "name": "Mouse Follows Focus",
     "description": "Are you a power-user?\nDo you like using Super+1,2,3 to access your favorite apps?\nAre you annoyed that you have to manually move your mouse between screens because it can't keep up with your keyboard shortcuts?\nThen this extension is for you!\n\nThis simple GNOME shell extension does the opposite of the 'focus follows mouse' setting. It makes the mouse follow your keyboard focus. Whenever you focus a window, if the cursor isn't already in it, it will jump to the windows center, making it easy to interact with it.",
     "uuid": "mousefollowsfocus@matthes.biz",
-    "shell-version": ["45"],
+    "shell-version": ["45", "46"],
     "version": 8,
     "url": "https://github.com/LeonMatthes/mousefollowsfocus"
 }


### PR DESCRIPTION
This PR just adds Gnome Shell support into extension.json. I tested it and as far as I can tell, the same code works for Gnome 46 as well.

This is also validated by some comments in this repo declaring that it works for them as well.